### PR TITLE
Require the Python 3 version of `geoip`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,22 @@
 import os
+
 from setuptools import setup
 
-with open(os.path.join(os.path.dirname(__file__),
-                       'VERSION')) as f:
+with open(os.path.join(os.path.dirname(__file__), "VERSION")) as f:
     version = f.read().strip()
 
 
 setup(
-    name='python-geoip-geolite2',
+    name="python-geoip-geolite2",
     version=version,
-    packages=['_geoip_geolite2'],
-    description='Provides access to the geolite2 database.  This product '
-        'includes GeoLite2 data created by MaxMind, available from '
-        'http://www.maxmind.com/',
-    install_requires=['python-geoip'],
+    packages=["_geoip_geolite2"],
+    description="Provides access to the geolite2 database.  This product "
+    "includes GeoLite2 data created by MaxMind, available from "
+    "http://www.maxmind.com/",
+    install_requires=["python-geoip-python3==1.3"],
     include_package_data=True,
     zip_safe=False,
     classifiers=[
-        'Programming Language :: Python',
+        "Programming Language :: Python",
     ],
 )


### PR DESCRIPTION
We're running into a very mysterious issue where a dependency introduced from this package, `python-geoip`, is shadowing a Python 3 variant of the same one. This should resolve that issue by explicitly requiring the Python 3 version.